### PR TITLE
Fix setting infoblock 2

### DIFF
--- a/blinkstick.rb
+++ b/blinkstick.rb
@@ -109,6 +109,6 @@ class BlinkStick
   end
 
   def info_block2=(value)
-    set_info_block(1, value)
+    set_info_block(2, value)
   end
 end


### PR DESCRIPTION
There is a typo in the setting function for infoblock 2. It's setting infoblock 1 instead.
